### PR TITLE
chore(release): close original phases + bump docs to v4.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hefesto will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.7] - 2026-02-14 — Release Closeout
+### Changed
+- **Docs**: MEMORY.md updated to reflect v4.8.6 reality (was stale at v4.8.5).
+- **Docs**: README inline changelog now includes v4.8.6 and v4.8.7 entries.
+- **Release**: Clean auditable tag after PR #5 merge + README parity fix.
+
 ## [4.8.6] - 2026-02-13 — Deterministic Smoke Tests
 ### Fixed
 - **Security**: Action fixture `critical_secret.py` now force-tracked in git (bypasses `.gitignore` `*secret*` pattern) so CI runners detect it correctly.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,7 +4,7 @@
 
 ---
 
-## PENDING: PyPI Release v4.8.5
+## PENDING: PyPI Release v4.8.7
 
 **STATUS: BLOCKED - Needs user action**
 
@@ -16,7 +16,7 @@
 3. Verify the primary email (check inbox for verification link)
 4. Once verified, re-push the tag to trigger the release workflow:
    ```bash
-   git push origin :refs/tags/v4.8.5 && git push origin v4.8.5
+   git push origin :refs/tags/v4.8.7 && git push origin v4.8.7
    ```
    The hardened workflow will now:
    - Publish to PyPI (with continue-on-error)
@@ -40,11 +40,11 @@
 
 | Location | Version | Status |
 |----------|---------|--------|
-| VM (installed) | 4.8.5 | OMEGA Guardian, editable install |
-| GitHub main | 4.8.5 | pyproject.toml at commit 5e517f1 |
-| Tag v4.8.5 | 4.8.5 | Annotated tag at 94de09b |
-| GitHub Release | v4.8.5 | Created as Latest |
-| OneDrive (local) | 4.8.5 | Synced to origin/main |
+| VM (installed) | 4.8.7 | OMEGA Guardian, editable install |
+| GitHub main | 4.8.7 | pyproject.toml (after PR merge) |
+| Tag v4.8.7 | 4.8.7 | To be created after PR merge |
+| GitHub Release | v4.8.6 | Latest (v4.8.7 pending) |
+| OneDrive (local) | 4.8.7 | Synced to origin/main |
 | PyPI | 4.5.5 | BLOCKED (email verification) |
 
 ---
@@ -60,8 +60,8 @@ git checkout main
 git reset --hard origin/main
 git clean -fd
 # Verify:
-grep "^version" pyproject.toml   # should show 4.8.5
-git describe --tags --always      # should show v4.8.5 or ahead
+grep "^version" pyproject.toml   # should show 4.8.7
+git describe --tags --always      # should show v4.8.7 or ahead
 ```
 
 ---
@@ -80,13 +80,13 @@ git describe --tags --always      # should show v4.8.5 or ahead
 ---
 
 ## Active Blockers
-- **Marketplace**: Smoke-test now deterministic after PR #5 merge (v4.8.6).
+- **Marketplace**: Smoke-test deterministic since PR #5. Version alignment verified at v4.8.7.
 - **PyPI Publishing**: BLOCKED due to pending email verification for `OmegaAI`.
-  - Action: Use Docker-based GitHub Action (Marketplace Ready v4.8.5).
+  - Action: Use Docker-based GitHub Action (Marketplace Ready v4.8.7).
   - Resync: See checklist below when email verified.
 
 ## Marketplace Status
-- **State**: Ready for manual publish (v4.8.5).
+- **State**: Ready for manual publish (v4.8.7, pending tag + release).
 - **Contract**: CLI Exit Code 2 = Issues Found.
 - **Inputs**: `fail_on`, `min_severity` (case-insensitive in Action).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Hefesto analyzes code using AI and catches issues that traditional linters miss:
 pip install hefesto-ai
 
 # 2. Verify
-hefesto --version  # Should show: 4.8.6
+hefesto --version  # Should show: 4.8.7
 
 # 3. Analyze
 cd your-project
@@ -50,7 +50,7 @@ steps:
   - uses: actions/checkout@v4
   - name: Run Hefesto Guardian
     id: hefesto
-    uses: artvepa80/Agents-Hefesto@v4.8.6
+    uses: artvepa80/Agents-Hefesto@v4.8.7
     with:
       target: '.'
       fail_on: 'CRITICAL'
@@ -459,6 +459,15 @@ We used Hefesto to validate itself before publishing v4.0.1:
 ---
 
 ## Changelog
+
+### v4.8.7 (2026-02-14)
+- **Docs**: Version alignment across MEMORY.md, README, CHANGELOG.
+- **Release**: Clean auditable closeout tag after PR #5 merge cycle.
+
+### v4.8.6 (2026-02-13)
+- **Security**: Force-tracked `critical_secret.py` fixture for CI runners.
+- **CI**: All 8 checks green (3.10/3.11/3.12 + parity + smoke + deploy).
+- **Dogfooding**: 0 CRITICAL issues verified before release.
 
 ### v4.8.5 (2026-02-13)
 - **GitHub Action**: Market-ready Docker-based action (bypassing PyPI).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hefesto-ai"
-version = "4.8.6"
+version = "4.8.7"
 description = "AI-Powered Code Quality Guardian with Gemini integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary\n\nCloses the original phased task (PR #5 cycle) with a clean auditable version bump.\n\n## Changes\n\n- **pyproject.toml**: `4.8.6` → `4.8.7`\n- **README.md**: Quick Start version + action snippet updated to `v4.8.7`; added v4.8.6 and v4.8.7 inline changelog entries\n- **CHANGELOG.md**: Added v4.8.7 entry (docs alignment + release closeout)\n- **MEMORY.md**: Version table updated from stale v4.8.5 → v4.8.7; marketplace status corrected\n\n## Checklist\n\n- [x] Docs parity: README + CHANGELOG + MEMORY aligned\n- [x] Version bump: pyproject 4.8.7\n- [x] No behavior changes\n- [x] Dogfooding: 0 CRITICAL issues\n- [x] Linters: black/isort/flake8 all clean\n- [x] Tests: 558 passed, 45 skipped, 0 failed\n\n## Exit Code Evidence\n\n```\nCLEAN_EXIT=0  (tests/fixtures/action/clean.py → no issues)\nCRIT_EXIT=2   (tests/fixtures/action/critical_secret.py → gate failure)\n```\n\n## Post-merge plan\n\n1. Squash-merge this PR\n2. Tag `v4.8.7` on merge commit\n3. Create GitHub Release v4.8.7\n4. Publish to Marketplace (manual checkbox)