### PR TITLE
OSS: optional wiring for PRO epics (scope/multilang/enrichment)

### DIFF
--- a/hefesto/core/analysis_models.py
+++ b/hefesto/core/analysis_models.py
@@ -205,6 +205,7 @@ class FileAnalysisResult:
     analysis_duration_ms: float
     language: Optional[str] = None
     provider_results: List[ProviderResult] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
@@ -218,6 +219,8 @@ class FileAnalysisResult:
             result["language"] = self.language
         if self.provider_results:
             result["providers"] = [pr.to_dict() for pr in self.provider_results]
+        if self.metadata:
+            result["file_meta"] = self.metadata
         return result
 
 
@@ -264,6 +267,8 @@ class AnalysisReport:
     ml_enabled: bool = False
     phase_0_enabled: bool = True
     phase_1_enabled: bool = False
+    # Optional metadata populated by PRO features (scope gating, multilang, etc.)
+    meta: Dict[str, Any] = field(default_factory=dict)
 
     def get_all_issues(self) -> List[AnalysisIssue]:
         """Get all issues across all files."""
@@ -282,11 +287,14 @@ class AnalysisReport:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        return {
+        result = {
             "summary": self.summary.to_dict(),
             "files": [file_result.to_dict() for file_result in self.file_results],
             "timestamp": self.timestamp.isoformat(),
         }
+        if self.meta:
+            result["meta"] = self.meta
+        return result
 
 
 __all__ = [

--- a/hefesto/pro_optional.py
+++ b/hefesto/pro_optional.py
@@ -1,0 +1,74 @@
+"""
+Optional imports from hefesto_pro (PRO add-on).
+
+OSS works without PRO installed. Each feature degrades to a no-op fallback
+when the corresponding PRO module is missing (ModuleNotFoundError).
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+# ---------------------------------------------------------------------------
+# EPIC 1 — Scope Gating
+# ---------------------------------------------------------------------------
+
+try:
+    from hefesto_pro.scope_gating.classifier import (  # type: ignore[import-untyped]
+        ScopeGatingConfig,
+    )
+    from hefesto_pro.scope_gating.orchestrator import (  # type: ignore[import-untyped]
+        build_scope_summary,
+        filter_paths,
+    )
+
+    HAS_SCOPE_GATING = True
+except ModuleNotFoundError:
+    HAS_SCOPE_GATING = False
+
+    class ScopeGatingConfig:  # type: ignore[no-redef]
+        """No-op fallback: all paths included, nothing skipped."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+    def filter_paths(  # type: ignore[misc]
+        paths: List[Path], config: Any
+    ) -> Tuple[List[Path], List[Any]]:
+        return list(paths), []
+
+    def build_scope_summary(skipped: List[Any]) -> Dict[str, Any]:  # type: ignore[misc]
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# EPIC 2 — Multi-Language Discovery
+# ---------------------------------------------------------------------------
+
+try:
+    from hefesto_pro.multilang.parser import TsJsParser  # type: ignore[import-untyped]
+    from hefesto_pro.multilang.skip_report import SkipReport  # type: ignore[import-untyped]
+
+    HAS_MULTILANG = True
+except ModuleNotFoundError:
+    HAS_MULTILANG = False
+    TsJsParser = None  # type: ignore[assignment, misc]
+    SkipReport = None  # type: ignore[assignment, misc]
+
+
+# ---------------------------------------------------------------------------
+# EPIC 3 — Safe Enrichment
+# ---------------------------------------------------------------------------
+
+try:
+    from hefesto_pro.enrichment import (  # type: ignore[import-untyped]
+        EnrichmentConfig,
+        EnrichmentInput,
+        EnrichmentOrchestrator,
+    )
+
+    HAS_ENRICHMENT = True
+except ModuleNotFoundError:
+    HAS_ENRICHMENT = False
+    EnrichmentConfig = None  # type: ignore[assignment, misc]
+    EnrichmentInput = None  # type: ignore[assignment, misc]
+    EnrichmentOrchestrator = None  # type: ignore[assignment, misc]

--- a/tests/test_pro_wiring.py
+++ b/tests/test_pro_wiring.py
@@ -1,0 +1,452 @@
+"""
+Tests for OSS ↔ PRO wiring (STOP 7).
+
+Validates that:
+A) CLI flags don't crash when PRO is not installed.
+B) pro_optional fallbacks work correctly.
+C) Simulated PRO via monkeypatch exercises the wiring.
+
+Copyright (c) 2025 Narapa LLC, Miami, Florida
+"""
+
+import importlib
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from click.testing import CliRunner
+
+from hefesto.cli.main import cli
+
+# ---------------------------------------------------------------------------
+# A) pro_optional fallbacks (no PRO installed)
+# ---------------------------------------------------------------------------
+
+
+class TestProOptionalFallbacks:
+    """Verify fallbacks when hefesto_pro is NOT installed."""
+
+    def test_has_flags_are_false(self):
+        from hefesto.pro_optional import HAS_ENRICHMENT, HAS_MULTILANG, HAS_SCOPE_GATING
+
+        assert HAS_SCOPE_GATING is False
+        assert HAS_MULTILANG is False
+        assert HAS_ENRICHMENT is False
+
+    def test_filter_paths_noop(self):
+        from hefesto.pro_optional import ScopeGatingConfig, filter_paths
+
+        paths = [Path("a.py"), Path("b.py")]
+        config = ScopeGatingConfig()
+        included, skipped = filter_paths(paths, config)
+        assert included == paths
+        assert skipped == []
+
+    def test_build_scope_summary_empty(self):
+        from hefesto.pro_optional import build_scope_summary
+
+        assert build_scope_summary([]) == {}
+
+    def test_multilang_sentinels_are_none(self):
+        from hefesto.pro_optional import SkipReport, TsJsParser
+
+        assert TsJsParser is None
+        assert SkipReport is None
+
+    def test_enrichment_sentinels_are_none(self):
+        from hefesto.pro_optional import (
+            EnrichmentConfig,
+            EnrichmentInput,
+            EnrichmentOrchestrator,
+        )
+
+        assert EnrichmentConfig is None
+        assert EnrichmentInput is None
+        assert EnrichmentOrchestrator is None
+
+
+# ---------------------------------------------------------------------------
+# B) CLI flags don't crash without PRO
+# ---------------------------------------------------------------------------
+
+
+def _has_tree_sitter() -> bool:
+    try:
+        import tree_sitter  # noqa: F401
+
+        return True
+    except ModuleNotFoundError:
+        return False
+
+
+class TestCLIFlagsNoCrash:
+    """All new flags must be accepted by Click even without PRO."""
+
+    def test_scope_flags_accepted(self, tmp_path):
+        sample = tmp_path / "hello.py"
+        sample.write_text("x = 1\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "analyze",
+                str(sample),
+                "--include-third-party",
+                "--include-generated",
+                "--include-fixtures",
+                "--scope-allow",
+                "src/",
+                "--scope-deny",
+                "vendor/",
+                "--quiet",
+            ],
+        )
+        # Click should parse all flags (exit 0 or 1, never 2 = Click usage error)
+        assert result.exit_code != 2, f"Click usage error: {result.output}"
+
+    def test_enrich_flags_accepted(self, tmp_path):
+        sample = tmp_path / "hello.py"
+        sample.write_text("x = 1\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "analyze",
+                str(sample),
+                "--enrich",
+                "local",
+                "--enrich-provider",
+                "MyProvider",
+                "--enrich-timeout",
+                "10",
+                "--enrich-cache-ttl",
+                "60",
+                "--enrich-cache-max",
+                "100",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code != 2, f"Click usage error: {result.output}"
+
+    @pytest.mark.skipif(not _has_tree_sitter(), reason="tree_sitter not installed")
+    def test_json_output_no_meta_without_pro(self, tmp_path):
+        # Use YAML file — tree-sitter needed for engine import
+        sample = tmp_path / "config.yml"
+        sample.write_text("key: value\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["analyze", str(sample), "--output", "json", "--quiet", "--severity", "LOW"],
+        )
+        assert result.exit_code in (0, 1), f"Unexpected exit: {result.exit_code}"
+        report = json.loads(result.output)
+        # Without PRO, meta should be absent (empty dict is omitted)
+        assert "meta" not in report
+
+
+# ---------------------------------------------------------------------------
+# C) Simulated PRO via monkeypatch
+# ---------------------------------------------------------------------------
+
+# --- Fake PRO modules ---
+
+
+@dataclass
+class _FakeScopeGatingConfig:
+    include_third_party: bool = False
+    include_generated: bool = False
+    include_fixtures: bool = False
+    extra_allow: List[str] = field(default_factory=list)
+    extra_deny: List[str] = field(default_factory=list)
+
+
+def _fake_filter_paths(paths: List[Path], config: Any) -> Tuple[List[Path], List[Dict[str, Any]]]:
+    """Simulates scope gating: skips any path containing 'vendor'."""
+    included = []
+    skipped = []
+    for p in paths:
+        if "vendor" in str(p):
+            skipped.append({"path": str(p), "kind": "third_party", "reason": "vendored"})
+        else:
+            included.append(p)
+    return included, skipped
+
+
+def _fake_build_scope_summary(skipped: List[Any]) -> Dict[str, Any]:
+    return {"total_skipped": len(skipped), "entries": skipped}
+
+
+@dataclass
+class _FakeParseResult:
+    imports: List[str] = field(default_factory=list)
+    functions: List[str] = field(default_factory=list)
+    classes: List[str] = field(default_factory=list)
+    exports: List[str] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+class _FakeTsJsParser:
+    def parse_text(self, file_path, code):
+        return _FakeParseResult(
+            imports=["react"],
+            functions=["render"],
+            classes=["App"],
+            exports=["default"],
+        )
+
+    def parse_bytes(self, file_path, data):
+        return _FakeParseResult(skipped=True, skip_reason="binary")
+
+
+class _FakeSkipReport:
+    def __init__(self):
+        self._entries = []
+
+    def add(self, path, reason, detail=None):
+        self._entries.append({"path": str(path), "reason": reason})
+
+    def to_dict(self):
+        return {"total_skipped": len(self._entries), "entries": self._entries}
+
+    def to_markdown(self):
+        return "\n".join(f"- {e['path']}: {e['reason']}" for e in self._entries)
+
+
+@dataclass
+class _FakeEnrichmentConfig:
+    enabled: bool = True
+    local_only: bool = False
+    timeout_seconds: float = 30.0
+    cache_ttl_seconds: int = 300
+    cache_max_size: int = 500
+    max_prompt_chars: int = 4000
+    max_snippet_chars: int = 2000
+    providers: List[str] = field(default_factory=list)
+
+
+@dataclass
+class _FakeEnrichmentInput:
+    file_path: str = ""
+    finding_summary: str = ""
+    repo_name: str = ""
+    language: str = ""
+    snippet: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _FakeEnrichmentResult:
+    status: str = "skipped"
+    provider: str = ""
+    summary: str = ""
+    error: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self):
+        return {"status": self.status, "provider": self.provider}
+
+
+class _FakeEnrichmentOrchestrator:
+    def __init__(self, providers=None, **kwargs):
+        self.call_count = 0
+
+    def run(self, inp, config=None):
+        self.call_count += 1
+        return _FakeEnrichmentResult(status="skipped", provider="none")
+
+
+def _inject_fake_pro(monkeypatch):
+    """Register fake hefesto_pro modules in sys.modules."""
+    # Create module hierarchy
+    pro = types.ModuleType("hefesto_pro")
+    sg = types.ModuleType("hefesto_pro.scope_gating")
+    sg_cls = types.ModuleType("hefesto_pro.scope_gating.classifier")
+    sg_orch = types.ModuleType("hefesto_pro.scope_gating.orchestrator")
+    ml = types.ModuleType("hefesto_pro.multilang")
+    ml_parser = types.ModuleType("hefesto_pro.multilang.parser")
+    ml_skip = types.ModuleType("hefesto_pro.multilang.skip_report")
+    enr = types.ModuleType("hefesto_pro.enrichment")
+
+    # Wire scope gating
+    sg_cls.ScopeGatingConfig = _FakeScopeGatingConfig
+    sg_orch.filter_paths = _fake_filter_paths
+    sg_orch.build_scope_summary = _fake_build_scope_summary
+
+    # Wire multilang
+    ml_parser.TsJsParser = _FakeTsJsParser
+    ml_skip.SkipReport = _FakeSkipReport
+
+    # Wire enrichment
+    enr.EnrichmentConfig = _FakeEnrichmentConfig
+    enr.EnrichmentInput = _FakeEnrichmentInput
+    enr.EnrichmentOrchestrator = _FakeEnrichmentOrchestrator
+
+    modules = {
+        "hefesto_pro": pro,
+        "hefesto_pro.scope_gating": sg,
+        "hefesto_pro.scope_gating.classifier": sg_cls,
+        "hefesto_pro.scope_gating.orchestrator": sg_orch,
+        "hefesto_pro.multilang": ml,
+        "hefesto_pro.multilang.parser": ml_parser,
+        "hefesto_pro.multilang.skip_report": ml_skip,
+        "hefesto_pro.enrichment": enr,
+    }
+
+    for name, mod in modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # Reload pro_optional so it picks up fake modules
+    import hefesto.pro_optional
+
+    importlib.reload(hefesto.pro_optional)
+
+
+def _cleanup_pro_optional(monkeypatch):
+    """Reload pro_optional to restore real (no-PRO) state."""
+    import hefesto.pro_optional
+
+    importlib.reload(hefesto.pro_optional)
+
+
+class TestSimulatedProScopeGating:
+    """With fake PRO injected, scope gating filters paths and populates meta."""
+
+    def test_scope_gating_filters_and_builds_meta(self, monkeypatch, tmp_path):
+        _inject_fake_pro(monkeypatch)
+        try:
+            from hefesto.pro_optional import HAS_SCOPE_GATING, ScopeGatingConfig, filter_paths
+
+            assert HAS_SCOPE_GATING is True
+
+            paths = [Path("src/app.py"), Path("vendor/x.js")]
+            config = ScopeGatingConfig()
+            included, skipped = filter_paths(paths, config)
+
+            assert len(included) == 1
+            assert included[0] == Path("src/app.py")
+            assert len(skipped) == 1
+            assert skipped[0]["kind"] == "third_party"
+        finally:
+            _cleanup_pro_optional(monkeypatch)
+
+    def test_scope_summary_in_report_meta(self, monkeypatch, tmp_path):
+        _inject_fake_pro(monkeypatch)
+        try:
+            from hefesto.pro_optional import build_scope_summary
+
+            skipped = [{"path": "vendor/x.js", "kind": "third_party"}]
+            summary = build_scope_summary(skipped)
+
+            assert summary["total_skipped"] == 1
+            assert summary["entries"] == skipped
+        finally:
+            _cleanup_pro_optional(monkeypatch)
+
+
+class TestSimulatedProMultilang:
+    """With fake PRO, multilang parser extracts symbols."""
+
+    def test_tsjs_parser_extracts_symbols(self, monkeypatch):
+        _inject_fake_pro(monkeypatch)
+        try:
+            from hefesto.pro_optional import HAS_MULTILANG, TsJsParser
+
+            assert HAS_MULTILANG is True
+            assert TsJsParser is not None
+
+            parser = TsJsParser()
+            result = parser.parse_text(Path("app.tsx"), "import React from 'react';")
+
+            assert "react" in result.imports
+            assert "render" in result.functions
+            assert "App" in result.classes
+        finally:
+            _cleanup_pro_optional(monkeypatch)
+
+
+class TestSimulatedProEnrichment:
+    """With fake PRO, enrichment orchestrator attaches per-finding metadata."""
+
+    def test_enrichment_orchestrator_returns_skipped(self, monkeypatch):
+        _inject_fake_pro(monkeypatch)
+        try:
+            from hefesto.pro_optional import (
+                HAS_ENRICHMENT,
+                EnrichmentConfig,
+                EnrichmentInput,
+                EnrichmentOrchestrator,
+            )
+
+            assert HAS_ENRICHMENT is True
+
+            orch = EnrichmentOrchestrator([])
+            inp = EnrichmentInput(file_path="a.py", finding_summary="test")
+            result = orch.run(inp, EnrichmentConfig())
+
+            assert result.status == "skipped"
+            d = result.to_dict()
+            assert d["status"] == "skipped"
+        finally:
+            _cleanup_pro_optional(monkeypatch)
+
+    @pytest.mark.skipif(not _has_tree_sitter(), reason="tree_sitter not installed")
+    def test_enrichment_off_by_default(self, tmp_path):
+        """Without --enrich flag, no enrichment metadata in findings."""
+        # Use YAML with a known issue pattern — tree-sitter needed for engine import
+        sample = tmp_path / "ci.yml"
+        sample.write_text("password: admin123\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["analyze", str(sample), "--output", "json", "--quiet", "--severity", "LOW"],
+        )
+        assert result.exit_code in (0, 1), f"Unexpected: {result.exit_code}"
+        report = json.loads(result.output)
+        for file_entry in report.get("files", []):
+            for issue in file_entry.get("issues", []):
+                meta = issue.get("metadata", {})
+                assert "enrichment" not in meta
+
+
+class TestEngineMultiPathAccumulation:
+    """Scope skipped list accumulates across multiple analyze_path() calls."""
+
+    @pytest.mark.skipif(not _has_tree_sitter(), reason="tree_sitter not installed")
+    def test_scope_skipped_extends_not_replaces(self, monkeypatch, tmp_path):
+        _inject_fake_pro(monkeypatch)
+        try:
+            from hefesto.core.analyzer_engine import AnalyzerEngine
+            from hefesto.pro_optional import ScopeGatingConfig
+
+            # Create two directories, each with a vendor file
+            d1 = tmp_path / "pkg1"
+            d1.mkdir()
+            (d1 / "app.py").write_text("x = 1\n")
+            v1 = d1 / "vendor"
+            v1.mkdir()
+            (v1 / "dep.js").write_text("var x = 1;\n")
+
+            d2 = tmp_path / "pkg2"
+            d2.mkdir()
+            (d2 / "lib.py").write_text("y = 2\n")
+            v2 = d2 / "vendor"
+            v2.mkdir()
+            (v2 / "dep2.js").write_text("var y = 2;\n")
+
+            engine = AnalyzerEngine(
+                severity_threshold="LOW",
+                verbose=False,
+                scope_config=ScopeGatingConfig(),
+            )
+
+            engine.analyze_path(str(d1))
+            engine.analyze_path(str(d2))
+
+            # Should have accumulated skipped from BOTH paths
+            assert len(engine._scope_skipped) >= 2
+        finally:
+            _cleanup_pro_optional(monkeypatch)


### PR DESCRIPTION
## Summary

Wire the three PRO EPICs into the OSS codebase via a new `hefesto/pro_optional.py` bridge module. OSS continues to work perfectly without `hefesto_pro` installed — all PRO features degrade to safe no-ops.

### Changes

| File | Type | Description |
|------|------|-------------|
| `hefesto/pro_optional.py` | **NEW** | Optional-import bridge with `ModuleNotFoundError` fallbacks for scope gating, multilang, and enrichment |
| `hefesto/cli/main.py` | MOD | 10 new Click flags (scope + enrichment), config builders, meta assembly |
| `hefesto/core/analyzer_engine.py` | MOD | Scope gating filter, multilang symbol extraction, per-finding enrichment, `_build_meta()` |
| `hefesto/core/analysis_models.py` | MOD | `meta` on `AnalysisReport`, `metadata` on `FileAnalysisResult` (backward-compatible) |
| `tests/test_pro_wiring.py` | **NEW** | 14 tests: fallbacks, CLI flags, monkeypatched PRO simulation, accumulation regression |

### Design decisions

- **`ModuleNotFoundError`** (not `ImportError`) — distinguishes "not installed" from "broken import"
- **Engine stores state, CLI assembles meta** — avoids double-building across multi-path runs
- **`_scope_skipped.extend()`** — accumulates across multiple `analyze_path()` calls
- **Per-finding enrichment** — attached at `issue.metadata["enrichment"]`, not report-level
- **Backward-compatible JSON** — `meta` and `file_meta` keys omitted when empty

### Test results

- 14/14 pass locally (tree-sitter available)
- Full suite: 277 pass, 7 fail (pre-existing), 8 skipped
- Zero new failures introduced

## Test plan

- [ ] CI passes all checks (pytest, flake8, black)
- [ ] Verify 14 new tests in `test_pro_wiring.py` pass
- [ ] Confirm no regression in existing test suite
- [ ] Verify JSON output backward compatibility (no `meta` key without PRO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)