### PR TITLE
fix(parsers): map c_sharp to csharp for tree-sitter-language-pack 1.x (Item 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AnalyzerEngine.__init__` accepts a new `quiet: bool = False` keyword
   argument, propagated by the CLI from `--quiet`.
 
+### Fixed
+- **C# parsing under `[multilang]` extra**: `tree-sitter-language-pack`'s
+  manifest registers C# under the canonical name `csharp`; Hefesto's
+  `LANG_MAP` passed through the legacy alias `c_sharp`, which is NOT in
+  the pack's manifest. With an empty download cache (every CI run, every
+  fresh user install), `get_parser("c_sharp")` failed with
+  `LanguageNotFoundError` and the parsers tarball was never downloaded —
+  every `.cs` file silent-skipped persistently. The bug was masked on
+  warm caches because `libtree_sitter_c_sharp.dylib` becomes
+  filesystem-resolvable once any other call (e.g. `get_parser("csharp")`)
+  has populated the cache, even though manifest lookup still fails.
+  Fixed by mapping `c_sharp` → `csharp` in `LANG_MAP`. Audited the full
+  `LANG_MAP` against the manifest; this is the only mismatch (the other
+  5 entries — `typescript`, `javascript`, `java`, `go`, `rust` — are
+  correct).
+
 ## [4.12.1] - 2026-04-27
 
 ### Fixed

--- a/hefesto/core/parsers/treesitter_parser.py
+++ b/hefesto/core/parsers/treesitter_parser.py
@@ -39,7 +39,7 @@ class TreeSitterParser(CodeParser):
         "java": "java",
         "go": "go",
         "rust": "rust",
-        "c_sharp": "c_sharp",
+        "c_sharp": "csharp",  # tree-sitter-language-pack manifest uses 'csharp'
     }
 
     def __init__(self, language: str):

--- a/tests/test_treesitter_parser.py
+++ b/tests/test_treesitter_parser.py
@@ -1,0 +1,77 @@
+"""Tests for TreeSitterParser internals.
+
+Covers regression scenarios for language-pack integration that are NOT
+exercised by ``tests/test_parser_failures.py`` (which mocks ``ParserFactory``
+and focuses on the surfacing layer added in Item 1).
+
+Copyright (c) 2025 Narapa LLC, Miami, Florida
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_pack_cache(tmp_path: Path):
+    """Redirect ``tree-sitter-language-pack``'s cache to ``tmp_path`` for the
+    duration of the test, then restore the default.
+
+    ``configure(cache_dir=...)`` is process-global state in the language pack;
+    leaving it pointed at a tmp dir would break unrelated tests, so we restore
+    on teardown via ``configure(cache_dir=None)``.
+
+    Skips automatically when the ``[multilang]`` extra is not installed.
+    """
+    try:
+        from tree_sitter_language_pack import configure
+    except ImportError:
+        pytest.skip("[multilang] extra not installed; cannot isolate pack cache")
+    configure(cache_dir=str(tmp_path))
+    try:
+        yield tmp_path
+    finally:
+        configure(cache_dir=None)
+
+
+@pytest.mark.integration
+def test_csharp_parses_with_cold_cache(isolated_pack_cache: Path) -> None:
+    """Regression: ``c_sharp`` must resolve via the language-pack manifest, not
+    rely on filesystem fallback from a previously-warmed cache.
+
+    Bug history:
+      - ``tree-sitter-language-pack`` 1.6.2 manifest registers C# under the
+        canonical name ``csharp``. The legacy alias ``c_sharp`` is NOT in the
+        manifest (verified empirically).
+      - Hefesto's ``LANG_MAP`` passed through ``c_sharp`` verbatim. With cold
+        cache (every CI run, every fresh user install), ``get_parser('c_sharp')``
+        failed with ``LanguageNotFoundError`` and the parsers tarball was never
+        downloaded — every ``.cs`` file silent-skipped persistently.
+      - The bug was masked on warm caches because
+        ``libtree_sitter_c_sharp.dylib`` becomes filesystem-resolvable once any
+        other call (e.g. ``get_parser('csharp')``) populates the cache, even
+        though manifest lookup still fails.
+
+    Regression guard: ``isolated_pack_cache`` redirects the pack's cache to
+    ``tmp_path``, guaranteeing a cold cache for this test regardless of host
+    state. Without the LANG_MAP fix, ``TreeSitterParser('c_sharp')`` raises
+    ``LanguageNotFoundError`` at construction. With the fix, it downloads to
+    ``tmp_path`` and parses successfully.
+    """
+    from hefesto.core.parsers.treesitter_parser import USE_PREBUILT, TreeSitterParser
+
+    if not USE_PREBUILT:
+        pytest.skip("[multilang] extra not installed; cannot exercise prebuilt path")
+
+    # Construction is the bug surface: pre-fix this line raises
+    # LanguageNotFoundError because LANG_MAP['c_sharp'] = 'c_sharp' (manifest miss).
+    parser = TreeSitterParser("c_sharp")
+
+    ast = parser.parse("class Foo { int Bar() { return 1; } }", "a.cs")
+
+    assert ast.root.children, (
+        "C# AST has no children — parser loaded grammar but produced "
+        "empty tree (degenerate case, not the LANG_MAP regression)"
+    )


### PR DESCRIPTION
## Bug

`tree-sitter-language-pack` 1.6.2 manifest registers C# under the
canonical name `csharp`. Hefesto's `LANG_MAP`
(`hefesto/core/parsers/treesitter_parser.py:36-43`) passed through the
legacy alias `c_sharp`, which is **NOT** in the manifest. With an empty
download cache (every CI run, every fresh user install),
`get_parser("c_sharp")` failed persistently with
`LanguageNotFoundError` and the parsers tarball was never downloaded
— **every `.cs` file silent-skipped on every run** for any user with
`[multilang]` installed.

## Why this was hard to spot

The bug is masked on warm caches. Once any other call (e.g.
`get_parser("csharp")`) populates
`~/Library/Caches/tree-sitter-language-pack/v1.6.2/libs/`, the file
`libtree_sitter_c_sharp.dylib` becomes filesystem-resolvable even
though manifest lookup still fails. So a developer running tests
locally after warming the cache via any other path would see C#
parsing work — but a fresh user install (CI runner, new venv with
clean home cache) hits the cold-cache failure deterministically.

## Empirical reproduction

Verified in `/tmp/hefesto-item2-venv` with
`tree-sitter-language-pack==1.6.2`:

```
# Cold cache + 3 calls to get_parser('c_sharp')
call #1: FAIL  LanguageNotFoundError: Download error: Language 'c_sharp' not available for download. Available groups: ["all"]
call #2: FAIL  (same)
call #3: FAIL  (same)

# Cold cache + get_parser('csharp')
csharp -> OK  (downloads pack to cache)

# After cache warm, get_parser('c_sharp')
c_sharp -> OK  (filesystem fallback finds libtree_sitter_c_sharp.dylib)
```

Manifest inspection confirms `csharp` is the only registered name in
the pack's 306-language manifest; `c_sharp` returns `null`.

## Fix

One-line change in `hefesto/core/parsers/treesitter_parser.py:42`:

```python
"c_sharp": "csharp",  # tree-sitter-language-pack manifest uses 'csharp'
```

`Language.CSHARP -> "c_sharp"` in `parser_factory.py:19` is unchanged
to preserve consistency with `_map_node_type` at line 189
(`elif language == "c_sharp":`). The translation to the language-pack
canonical name is contained inside `LANG_MAP`.

## LANG_MAP audit

Audited the full `LANG_MAP` against the language-pack manifest;
`c_sharp` is the **only** mismatch. The other 5 entries
(`typescript`, `javascript`, `java`, `go`, `rust`) are correct as-is.

## Regression test

`tests/test_treesitter_parser.py` (new file) — uses the language-pack's
public `configure(cache_dir=tmp_path)` API to force a cold cache per
test, guaranteeing reproduction of the user-facing scenario regardless
of host cache state. The fixture restores the default cache directory
in teardown to avoid leaking state to other tests. Marked
`@pytest.mark.integration`; skips when `[multilang]` is not installed.

## Independence from #29

Zero file overlap with PR #29 (Item 1 surfaces the symptom):

- This PR touches `hefesto/core/parsers/treesitter_parser.py` (1 line)
  + `tests/test_treesitter_parser.py` (new file) + `CHANGELOG.md`.
- PR #29 touches `hefesto/core/analyzer_engine.py` +
  `hefesto/cli/main.py` + `tests/test_parser_failures.py` + `CHANGELOG.md`
  + `docs/PRO_OPTIONAL_FEATURES.md`.

The only shared file is `CHANGELOG.md`, where #29 adds under
`### Added` and this PR adds under `### Fixed` — distinct sub-sections,
no merge conflict expected.

#29's mock-based parametrized tests pass `.cs` as a fixture but mock
`ParserFactory.get_parser` to raise `OSError`, so the real
`TreeSitterParser("c_sharp")` path is never invoked and Item 7's fix
doesn't affect them. The integration test in #29 uses `.js` only.

## Tests

- `pytest tests/test_treesitter_parser.py -m integration` in venv with
  `[multilang]`: **PASSED** (6.05s — includes parser pack download to
  isolated `tmp_path`).
- `pytest tests/ -m "not integration"`: **531 passed, 6 skipped, 1
  deselected, 0 failures** (no regression).
- `black --check`, `isort --check`, `flake8`: clean.

## Test plan

- [ ] Reviewer pulls branch, runs `pytest tests/test_treesitter_parser.py -m integration -v`
- [ ] Reviewer runs full suite (`pytest tests/ -q`) — 531 passed expected
- [ ] Reviewer verifies the `LANG_MAP` audit claim by running:
  ```python
  import json
  m = json.load(open("/Users/<you>/Library/Caches/tree-sitter-language-pack/v1.6.2/manifest.json"))
  for n in ["typescript", "javascript", "java", "go", "rust", "c_sharp", "csharp"]:
      print(n, "in manifest:" , n in m["languages"])
  ```
- [ ] No auto-merge — manual review on GitHub.