### PR TITLE
chore(deps): pin tree-sitter-language-pack >=1.0.0,<2.0 (Item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AnalyzerEngine.__init__` accepts a new `quiet: bool = False` keyword
   argument, propagated by the CLI from `--quiet`.
 
+### Changed
+- **Tightened `[multilang]` extra pin**: `tree-sitter-language-pack>=1.0.0,<2.0`
+  (was `>=0.7.0`, no upper bound).
+  - Documents the actual compat range of the API surface used by Hefesto today
+    (PyPI latest 1.6.2 satisfies the new range).
+  - Rules out 0.x lines that no longer track `tree-sitter` core's current
+    `Language` signature — the same drift surfaced as `TypeError` in Item 1's
+    integration test of the deprecated manual fallback path.
+  - Prevents accidental future drift to a 2.x major before the API surface is
+    re-verified.
+  - No change for users who installed `[multilang]` after early-2025 (pip was
+    already resolving to 1.x).
+
 ### Fixed
 - **C# parsing under `[multilang]` extra**: `tree-sitter-language-pack`'s
   manifest registers C# under the canonical name `csharp`; Hefesto's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ ml = [
     "torch>=2.0.0",
 ]
 multilang = [
-    "tree-sitter-language-pack>=0.7.0",
+    "tree-sitter-language-pack>=1.0.0,<2.0",
 ]
 ci = [
     "pyyaml>=6.0,<7.0",


### PR DESCRIPTION
## What

Tightens the `[multilang]` extra pin in `pyproject.toml`:

```diff
 multilang = [
-    "tree-sitter-language-pack>=0.7.0",
+    "tree-sitter-language-pack>=1.0.0,<2.0",
 ]
```

## Why

- **Documents the actual compat range** of the API surface used today.
  PyPI latest 1.6.2 satisfies the new range; pre-existing installs after
  early-2025 are already on 1.x by pip's resolution.
- **Rules out 0.x lines** that no longer track `tree-sitter` core's
  current `Language` signature. This is the same drift category that
  surfaced as `TypeError` in PR #29's integration test of the deprecated
  manual fallback path (`treesitter_parser.py:51-65`, tracked
  separately as Item 5).
- **Prevents accidental drift to 2.x** before the API surface is
  re-verified — language-pack's manifest format and grammar coverage
  could change in a major bump.
- The C# `LANG_MAP` rename in PR #30 is what makes this pin
  load-bearing: it ensures we're locked into the manifest behavior
  that `csharp` is registered under (verified empirically against
  the 1.6.2 manifest in PR #30's audit).

## Verification

Clean-venv install (Python 3.12, fresh):

```
pip install -e ".[multilang]"
# →  tree-sitter-language-pack 1.6.2  (resolves cleanly within new range)
# →  tree-sitter 0.25.2               (within existing >=0.20.0,<1.0.0)
```

No conflicts; `pip` selects the same 1.6.2 it already selects on the
old `>=0.7.0` pin today.

## Tests

- `pytest tests/ -m "not integration"`: 531 passed, 6 skipped
- `black --check`, `isort --check`, `flake8`: clean

## Test plan

- [ ] Reviewer runs `pip install -e ".[multilang]"` in a fresh venv, confirms `tree-sitter-language-pack` resolves to 1.x
- [ ] Reviewer reviews `pyproject.toml:75-77` diff for the single-line change
- [ ] No auto-merge — manual review on GitHub