### PR TITLE
ci: add multilang extra smoke job (Item 3)

### DIFF
--- a/.github/workflows/multilang-smoke.yml
+++ b/.github/workflows/multilang-smoke.yml
@@ -1,0 +1,92 @@
+# Smoke job for the [multilang] extra.
+#
+# Validates that `pip install hefesto-ai[multilang]` resolves cleanly and that
+# `tree_sitter_language_pack.get_parser(<lang>)` returns a working parser for
+# each of the 6 languages Hefesto supports through the extra.
+#
+# This job is INTENTIONALLY narrow — it does NOT validate:
+#   - Hefesto's `meta.parser_failures` surfacing (see test_parser_failures.py)
+#   - `HAS_MULTILANG=False` graceful degradation when the extra is absent
+#   - Hefesto's TreeSitterParser wrapper (redundant with integration tests)
+#   - The bridge to PRO (`hefesto.pro_optional`)
+#
+# Naming map (three names exist for C# in this codebase; do not "correct" them):
+#   - `Language.CSHARP.value`                                    = "csharp"
+#   - `ParserFactory.GRAMMAR_NAMES[Language.CSHARP]`             = "c_sharp"
+#   - `LANG_MAP["c_sharp"]` (translates to language-pack)        = "csharp"
+#   - `tree_sitter_language_pack` manifest canonical name        = "csharp"
+# This smoke uses the manifest canonical name ("csharp", no underscore)
+# because it calls `get_parser` directly, bypassing Hefesto's layers.
+
+name: Multilang Extra Smoke
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: multilang-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  multilang-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install [multilang] extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[multilang]"
+
+      - name: Smoke — get_parser + parse for the 6 supported languages
+        run: |
+          python - <<'PY'
+          from tree_sitter_language_pack import get_parser
+
+          # Manifest canonical names (NOT Hefesto's internal LANG_MAP keys).
+          # See workflow header comment for the naming map rationale.
+          samples = {
+              "javascript": b"function f() { return 1; }",
+              "typescript": b"function f(): number { return 1; }",
+              "java":       b"class Foo { int bar() { return 1; } }",
+              "go":         b"package main\nfunc Foo() int { return 1 }\n",
+              "rust":       b"pub fn foo() -> i32 { 1 }",
+              "csharp":     b"class Foo { int Bar() { return 1; } }",
+          }
+          failures = []
+          for lang, code in samples.items():
+              try:
+                  parser = get_parser(lang)
+                  if parser is None:
+                      failures.append(f"{lang}: get_parser returned None")
+                      continue
+                  tree = parser.parse(code)
+                  if not tree.root_node.children:
+                      failures.append(f"{lang}: AST has no children (empty parse)")
+                      continue
+                  print(f"  {lang:12s} -> OK ({len(tree.root_node.children)} top-level nodes)")
+              except Exception as e:
+                  failures.append(f"{lang}: {type(e).__name__}: {e}")
+          if failures:
+              print("FAILURES:")
+              for f in failures:
+                  print(f"  - {f}")
+              raise SystemExit(1)
+          print("All 6 languages OK")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `multilang`, `scope`, `reliability_pack_summary`).
 - `AnalyzerEngine.__init__` accepts a new `quiet: bool = False` keyword
   argument, propagated by the CLI from `--quiet`.
+- **CI smoke for `[multilang]` extra**: new workflow
+  `.github/workflows/multilang-smoke.yml` validates that
+  `pip install -e ".[multilang]"` resolves cleanly and that
+  `tree_sitter_language_pack.get_parser(<lang>)` returns a working
+  parser for each of the 6 supported languages
+  (`javascript`, `typescript`, `java`, `go`, `rust`, `csharp`) under
+  Python 3.10–3.13. Asserts that each parsed AST has at least one
+  top-level node. Scope is intentionally narrow: this job does NOT
+  validate Hefesto's `meta.parser_failures` surfacing, the PRO bridge,
+  or graceful degradation without the extra — those properties are
+  defended by their own tests. Workflow header documents the
+  three-name mapping (`Language.CSHARP.value` / `GRAMMAR_NAMES` /
+  `LANG_MAP` / language-pack manifest) so future readers don't
+  "correct" the intentional naming layers.
 
 ### Changed
 - **Tightened `[multilang]` extra pin**: `tree-sitter-language-pack>=1.0.0,<2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "correct" the intentional naming layers.
 
 ### Changed
+- **Defense against `tree-sitter-language-pack` 1.6.3 broken cp312 wheel**:
+  upstream's 1.6.3 release shipped only a `cp312-cp312` wheel whose top-level
+  directory was renamed to `_native/`, breaking
+  `import tree_sitter_language_pack` on Python 3.12. The new
+  `multilang-smoke` workflow (added in this same PR) caught this on its
+  first run. Pin extended to `>=1.0.0,!=1.6.3,<2.0` to skip the broken
+  release; `1.7.0+` is unaffected and resolves automatically. Tracked
+  upstream as `kreuzberg-dev/tree-sitter-language-pack#108` (closed;
+  malformed publish, superseded by 1.7.0) and `#116` (open).
 - **Tightened `[multilang]` extra pin**: `tree-sitter-language-pack>=1.0.0,<2.0`
   (was `>=0.7.0`, no upper bound).
   - Documents the actual compat range of the API surface used by Hefesto today

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,12 @@ ml = [
     "torch>=2.0.0",
 ]
 multilang = [
-    "tree-sitter-language-pack>=1.0.0,<2.0",
+    # 1.6.3 excluded: upstream's malformed accidental publish ships only a
+    # cp312 wheel whose top-level was renamed to `_native/`, breaking
+    # `import tree_sitter_language_pack` on Python 3.12. Tracked upstream as
+    # kreuzberg-dev/tree-sitter-language-pack#108 (closed; superseded by
+    # 1.7.0) and #116 (open). 1.7.0+ is unaffected.
+    "tree-sitter-language-pack>=1.0.0,!=1.6.3,<2.0",
 ]
 ci = [
     "pyyaml>=6.0,<7.0",


### PR DESCRIPTION
## What

Adds `.github/workflows/multilang-smoke.yml` — a new concern-specific
workflow (matching the repo convention of `action-smoke.yml`,
`capabilities-parity.yml`, `readme-parity.yml`).

The job validates two things:

1. `pip install -e ".[multilang]"` resolves cleanly under Python
   3.10–3.13.
2. `tree_sitter_language_pack.get_parser(<lang>)` returns a working
   parser for each of the 6 languages Hefesto supports through the
   extra (`javascript`, `typescript`, `java`, `go`, `rust`, `csharp`),
   and the parsed AST has at least one top-level node.

## Why this depends on PR #30 already being merged

The smoke uses the language-pack manifest's canonical name `csharp`,
not Hefesto's internal `c_sharp`. Item 7 (PR #30) was the rename of
`LANG_MAP["c_sharp"] = "csharp"` that made the actual user-facing
parsing path work. This smoke is what would have caught that bug
before it shipped — adding it now closes that gap as a permanent
guardrail.

## Scope is intentionally narrow

The workflow header documents what this job does NOT validate:

- NOT `meta.parser_failures` surfacing (defended by
  `tests/test_parser_failures.py`, PR #29)
- NOT `HAS_MULTILANG=False` graceful degradation when the extra
  is absent (separate concern)
- NOT Hefesto's `TreeSitterParser` wrapper (defended by
  `tests/test_treesitter_parser.py`, PR #30)
- NOT the bridge to PRO (`hefesto.pro_optional`)

The header also documents the three-name mapping
(`Language.CSHARP.value` / `GRAMMAR_NAMES` / `LANG_MAP` / language-pack
manifest) so future readers don't "correct" the intentional naming
layers.

## Branch protection — manual step required

Per `gh api .../branches/main/protection` → `404 Branch not protected`,
the repo currently has **no branch protection rules configured**.
"Required checks" is by convention today, not by enforcement.

For this smoke to actually block merges (rather than just run and be
visible), the repo admin needs to manually configure branch protection
in GitHub UI after this PR opens its first run:

> Settings → Branches → Branch protection rules → Add rule
> - Branch name pattern: `main`
> - Require a pull request before merging
> - Require status checks to pass before merging
> - Add: `multilang-smoke (3.10)`, `(3.11)`, `(3.12)`, `(3.13)`
> - Optionally formalize existing convention checks: `CI`,
>   `Capabilities Parity`, `wheel-leak-check`

GitHub only lets you add checks to required-status-checks once they've
run at least once on the repo. This PR's first run registers the four
matrix jobs so they become selectable.

## Validation

- `actionlint 1.7.12` on `multilang-smoke.yml`: clean (existing warnings
  in `action-smoke.yml` are pre-existing, unrelated).

## Test plan

- [ ] First run of `multilang-smoke (3.10|3.11|3.12|3.13)` on this PR all green
- [ ] Reviewer confirms the 6-language parse loop matches the manifest names (no `c_sharp`)
- [ ] Repo admin adds the 4 jobs to branch protection required checks before merging
- [ ] No auto-merge — manual review on GitHub