### PR TITLE
docs: align install surfaces with [multilang] + fix package name typo (Item 9)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ hefesto/
 
 - **Version:** 4.12.1
 - **Tests:** 531 across 38 test files
-- **Languages:** Python (native AST), TypeScript, JavaScript, Java, Go, Rust, C# (TreeSitter)
+- **Languages:** Python (native AST), TypeScript, JavaScript, Java, Go, Rust, C# (TreeSitter — requires `pip install "hefesto-ai[multilang]"`)
 - **DevOps:** YAML, Terraform, Shell, Dockerfile, SQL, PowerShell, JSON, TOML, Makefile, Groovy
 - **Cloud:** CloudFormation, ARM Templates, Helm Charts, Serverless Framework
 - **PyPI:** `pip install hefesto-ai`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No change for users who installed `[multilang]` after early-2025 (pip was
     already resolving to 1.x).
 
+### Documentation
+- Aligned `README.md`, `.github/copilot-instructions.md`,
+  `docs/INSTALLATION.md`, `docs/QUICK_START.md`, and
+  `docs/GETTING_STARTED.md` with the new `[multilang]` extra surfacing
+  introduced in this release. The 6 tree-sitter languages (TypeScript,
+  JavaScript, Java, Go, Rust, C#) now have explicit install instructions
+  across all install-related surfaces. Framing chosen: `[multilang]` is
+  **required** for those languages (matches the runtime stderr warning
+  users see if they skip the extra), not "optional but recommended".
+- Fixed pre-existing typo `pip install hefesto` → `pip install hefesto-ai`
+  in `docs/QUICK_START.md` (2 occurrences) and `docs/INSTALLATION.md`
+  (3 occurrences, including the uninstall command).
+
 ### Fixed
 - **C# parsing under `[multilang]` extra**: `tree-sitter-language-pack`'s
   manifest registers C# under the canonical name `csharp`; Hefesto's

--- a/README.md
+++ b/README.md
@@ -184,12 +184,18 @@ See [`examples/github-actions/README.md`](examples/github-actions/README.md) for
 | Language | Parser | Status |
 |----------|--------|--------|
 | Python | Native AST | Full support |
-| TypeScript | TreeSitter | Full support |
-| JavaScript | TreeSitter | Full support |
-| Java | TreeSitter | Full support |
-| Go | TreeSitter | Full support |
-| Rust | TreeSitter | Full support |
-| C# | TreeSitter | Full support |
+| TypeScript | TreeSitter | Full support¹ |
+| JavaScript | TreeSitter | Full support¹ |
+| Java | TreeSitter | Full support¹ |
+| Go | TreeSitter | Full support¹ |
+| Rust | TreeSitter | Full support¹ |
+| C# | TreeSitter | Full support¹ |
+
+¹ TreeSitter languages require the `[multilang]` extra:
+`pip install "hefesto-ai[multilang]"`. Without it, files in these
+languages are skipped at parse time and Hefesto emits a stderr warning
+pointing to the install command (also exposed via
+`report.meta.parser_failures` in JSON output).
 
 ### DevOps & Configuration
 
@@ -226,7 +232,7 @@ See [`examples/github-actions/README.md`](examples/github-actions/README.md) for
 # FREE tier
 pip install hefesto-ai
 
-# TS/JS parsing + symbol metadata (optional)
+# Required for TypeScript, JavaScript, Java, Go, Rust, and C# analysis
 pip install "hefesto-ai[multilang]"
 
 # PRO tier

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -17,9 +17,17 @@
 # Install from PyPI
 pip install hefesto-ai
 
+# Required for TypeScript, JavaScript, Java, Go, Rust, or C# analysis:
+pip install "hefesto-ai[multilang]"
+
 # Verify installation
 hefesto --version
 ```
+
+Without the `[multilang]` extra, files in those 6 languages are skipped
+at parse time and Hefesto emits a stderr warning pointing to the install
+command (also exposed via `report.meta.parser_failures` in JSON output).
+Python (`.py`) analysis works without the extra.
 
 **Expected output:**
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -13,11 +13,26 @@
 
 ```bash
 # Free version (Phase 0)
-pip install hefesto
+pip install hefesto-ai
 
 # Pro version (Phase 1)
 pip install hefesto-ai[pro]
 ```
+
+### Multi-language Support (TS / JS / Java / Go / Rust / C#)
+
+Analysis of TypeScript, JavaScript, Java, Go, Rust, and C# requires
+the `[multilang]` extra. Without it, files in these languages are
+skipped at parse time and Hefesto emits a `parser_unavailable` warning
+to stderr at the end of the run (also exposed as
+`report.meta.parser_failures` in JSON output).
+
+```bash
+pip install "hefesto-ai[multilang]"
+```
+
+This installs `tree-sitter-language-pack` (165+ pre-built grammars).
+Python (`.py`) analysis works without this extra.
 
 ### Method 2: From Source
 
@@ -107,7 +122,7 @@ curl http://localhost:8080/ping
 
 **Solution**:
 ```bash
-pip install --upgrade hefesto
+pip install --upgrade hefesto-ai
 ```
 
 ### GEMINI_API_KEY not set
@@ -146,7 +161,7 @@ export GOOGLE_APPLICATION_CREDENTIALS='/path/to/key.json'
 ## Uninstallation
 
 ```bash
-pip uninstall hefesto
+pip uninstall hefesto-ai
 ```
 
 ## Next Steps

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -5,7 +5,11 @@ Get up and running with Hefesto in 5 minutes.
 ## 1. Install Hefesto
 
 ```bash
-pip install hefesto
+pip install hefesto-ai
+
+# For TypeScript, JavaScript, Java, Go, Rust, or C# analysis,
+# also install the multilang extra:
+pip install "hefesto-ai[multilang]"
 ```
 
 ## 2. Set API Key
@@ -134,7 +138,7 @@ Add to `.github/workflows/quality.yml`:
 ```yaml
 - name: Code Quality
   run: |
-    pip install hefesto
+    pip install hefesto-ai
     hefesto serve &
     sleep 5
     # Your CI tests here


### PR DESCRIPTION
## What

Post-merge doc cleanup for the 4 PRs that landed in main today
(#29, #30, #31, #32). Two concerns bundled in one PR because they
touch the same install-related surfaces.

### Block 1 — Document the `[multilang]` extra requirement

The 4 PRs introduced a new behavior: when the user installs Hefesto
without `[multilang]` and analyzes TypeScript/JavaScript/Java/Go/Rust/C#
files, Hefesto now emits a stderr warning at end of analysis (Item 1)
and exposes `report.meta.parser_failures` in JSON output. Previously
those skips were silent.

This PR updates 5 install-facing docs to say upfront that `[multilang]`
is required for those 6 languages, so users don't have to discover
it via the runtime warning:

- `README.md` — Code Languages table footnote + broadened install comment
- `.github/copilot-instructions.md` — added install hint to Languages line
- `docs/INSTALLATION.md` — new "Multi-language Support" subsection
- `docs/QUICK_START.md` — install step mentions the extra
- `docs/GETTING_STARTED.md` — install step mentions the extra

**Framing chosen**: `[multilang]` is **required** for the 6 tree-sitter
languages (matches the runtime stderr warning users actually see),
**not** "optional but recommended". Consistent across all 5 files.

### Block 2 — Fix pre-existing `hefesto` → `hefesto-ai` typo

5 occurrences caught while auditing install surfaces:

- `docs/QUICK_START.md:8` — `pip install hefesto`
- `docs/QUICK_START.md:137` — `pip install hefesto` (CI/CD example)
- `docs/INSTALLATION.md:16` — `pip install hefesto`
- `docs/INSTALLATION.md:110` — `pip install --upgrade hefesto`
- `docs/INSTALLATION.md:149` — `pip uninstall hefesto`

These would silently fail or install the wrong package (`hefesto`
vs `hefesto-ai`). Pre-existing bug, bundled here to avoid leaving
the typo for another cycle.

## Verification

- `grep "pip.*hefesto" <modified files> | grep -v "hefesto-ai"` → zero matches
- 6 files changed, 59 insertions, 13 deletions
- No code changes; docs and CHANGELOG only

## Test plan

- [ ] Reviewer confirms framing A (`[multilang]` is required, not optional) is
  consistent across all 5 surfaces
- [ ] Reviewer copies a `pip install` line from each modified doc and verifies it works
- [ ] No auto-merge — manual review on GitHub