### PR TITLE
fix(reliability): avoid R3 false positive for self-managed connections

### DIFF
--- a/hefesto/security/packs/resource_safety_v1.py
+++ b/hefesto/security/packs/resource_safety_v1.py
@@ -245,8 +245,23 @@ class ResourceSafetyAnalyzer:
     def _r3_session_lifecycle(
         self, py_tree: ast.Module, file_path: str, code: str
     ) -> List[AnalysisIssue]:
-        """Detect Session()/connect() without context-manager or close()."""
+        """Detect Session()/connect() without context-manager or close().
+
+        Recognizes two cleanup patterns:
+
+        * Local variable: ``conn = connect(); ...; conn.close()`` or
+          ``with connect() as conn:`` within the same function.
+        * Self-managed attribute: ``self._conn = connect()`` inside a method,
+          when the enclosing class defines a sibling method whose body calls
+          ``self._conn.close()`` (lazy-getter cache pattern).
+
+        Findings are only emitted when the assigned target's name can be
+        extracted (``ast.Name`` or ``ast.Attribute`` on ``self``); unnamed
+        targets are skipped to avoid the historical ``var_name=None`` bug
+        that produced messages containing the literal ``'None'``.
+        """
         issues: List[AnalysisIssue] = []
+        class_close_index = self._build_class_close_index(py_tree)
 
         for node in ast.walk(py_tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -262,15 +277,22 @@ class ResourceSafetyAnalyzer:
                 if call_name not in _SESSION_CONSTRUCTORS:
                     continue
 
-                # Get the assigned variable name
-                var_name = None
-                if child.targets and isinstance(child.targets[0], ast.Name):
-                    var_name = child.targets[0].id
+                target = child.targets[0] if child.targets else None
+                var_name, attr_name = self._extract_target_names(target)
 
-                # Check if used in with-statement or .close() called
-                if self._has_cleanup(node, var_name, child.lineno):
+                # Skip findings we cannot meaningfully describe.
+                if var_name is None and attr_name is None:
                     continue
 
+                # Same-function cleanup (local variable case).
+                if var_name and self._has_cleanup(node, var_name, child.lineno):
+                    continue
+
+                # Cross-method cleanup (self.<attr> managed by a sibling method).
+                if attr_name and class_close_index.get(attr_name):
+                    continue
+
+                display_name = var_name or f"self.{attr_name}"
                 issues.append(
                     AnalysisIssue(
                         file_path=file_path,
@@ -279,12 +301,12 @@ class ResourceSafetyAnalyzer:
                         issue_type=AnalysisIssueType.RELIABILITY_SESSION_LIFECYCLE,
                         severity=AnalysisIssueSeverity.MEDIUM,
                         message=(
-                            f"'{call_name}()' assigned to '{var_name}' without "
+                            f"'{call_name}()' assigned to '{display_name}' without "
                             "context-manager or explicit .close() — potential connection leak."
                         ),
                         suggestion=(
-                            f"Use 'with {call_name}() as {var_name}:' or ensure "
-                            f"'{var_name}.close()' in a finally block."
+                            f"Use 'with {call_name}() as {display_name}:' or ensure "
+                            f"'{display_name}.close()' in a finally block."
                         ),
                         function_name=node.name,
                         engine=_ENGINE,
@@ -294,6 +316,62 @@ class ResourceSafetyAnalyzer:
                     )
                 )
         return issues
+
+    @staticmethod
+    def _extract_target_names(
+        target: Optional[ast.AST],
+    ) -> "tuple[Optional[str], Optional[str]]":
+        """Return ``(local_var_name, self_attr_name)`` for an assign target.
+
+        - ``conn = ...`` → ``("conn", None)``
+        - ``self._conn = ...`` → ``(None, "_conn")``
+        - anything else → ``(None, None)``
+        """
+        if isinstance(target, ast.Name):
+            return target.id, None
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            return None, target.attr
+        return None, None
+
+    @staticmethod
+    def _build_class_close_index(py_tree: ast.Module) -> Dict[str, bool]:
+        """Index ``self.<attr>`` names whose ``.close()`` (or other
+        :data:`_CLOSE_METHODS`) is invoked by any method of the enclosing class.
+
+        Pattern recognized::
+
+            class Foo:
+                def close(self):
+                    self._conn.close()   # → index["_conn"] = True
+
+        Conservative: only direct ``self.<attr>.<close-method>()`` invocations.
+        Enough for the lazy-getter cache pattern without introducing
+        interprocedural complexity.
+        """
+        index: Dict[str, bool] = {}
+        for cls in ast.walk(py_tree):
+            if not isinstance(cls, ast.ClassDef):
+                continue
+            for sub in ast.walk(cls):
+                if not isinstance(sub, ast.Call):
+                    continue
+                func = sub.func
+                if not isinstance(func, ast.Attribute):
+                    continue
+                if func.attr not in _CLOSE_METHODS:
+                    continue
+                receiver = func.value
+                if (
+                    isinstance(receiver, ast.Attribute)
+                    and isinstance(receiver.value, ast.Name)
+                    and receiver.value.id == "self"
+                ):
+                    index[receiver.attr] = True
+        return index
 
     @staticmethod
     def _call_name(call_node: ast.Call) -> str:

--- a/tests/fixtures/reliability_drift/r3_self_attr_managed.py
+++ b/tests/fixtures/reliability_drift/r3_self_attr_managed.py
@@ -1,0 +1,28 @@
+"""R3 negative fixture: self-managed connection with explicit close() method.
+
+Mirrors the lazy-getter cache pattern observed in
+``swarm/storage/sqlite_store.py`` (PRO repo) which triggered an R3 false
+positive during EPIC 4 Phase D warn soak (FP-1, 2026-05-08).
+
+Expected behavior: R3 must NOT emit a finding for ``self._conn`` because
+the same class defines a ``close()`` method that closes the connection.
+"""
+
+import sqlite3
+
+
+class SwarmStoreLike:
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self._conn = None
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.db_path)
+            self._conn.row_factory = sqlite3.Row
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/tests/test_resource_safety_v1.py
+++ b/tests/test_resource_safety_v1.py
@@ -53,6 +53,45 @@ def test_r3_session_lifecycle_detected():
     assert "close" in r3[0].suggestion.lower() or "with" in r3[0].suggestion.lower()
 
 
+def test_r3_self_attribute_with_close_method_no_finding():
+    """Lazy-getter cache pattern: self._conn = connect() + class-level close().
+
+    Mirrors swarm/storage/sqlite_store.py (PRO repo) FP-1 from EPIC 4 Phase D
+    warn soak (2026-05-08). The class manages connection lifecycle via an
+    explicit close() method that calls self._conn.close(); R3 must recognize
+    this pattern and NOT emit a finding.
+    """
+    issues = _run("r3_self_attr_managed.py")
+    r3 = [i for i in issues if i.issue_type == AnalysisIssueType.RELIABILITY_SESSION_LIFECYCLE]
+    assert r3 == [], (
+        "Lazy-getter cache + class-level close() should not trigger R3, "
+        f"got {len(r3)} finding(s): {[(i.line, i.message) for i in r3]}"
+    )
+
+
+def test_r3_message_never_contains_assigned_to_none():
+    """R3 messages must never contain the literal "'None'" as the assigned
+    variable. Prior bug: ast.Attribute targets (e.g., self._conn) fell through
+    to var_name=None and produced messages like
+    "'connect()' assigned to 'None' without ...".
+
+    This regression guard scans every R3 emission across every reliability
+    fixture in the repo, including fixtures that intentionally use
+    self-attribute targets.
+    """
+    fixtures = sorted(FIXTURES_DIR.glob("*.py"))
+    assert fixtures, "no reliability fixtures discovered"
+
+    for fixture in fixtures:
+        issues = _run(fixture.name)
+        for i in issues:
+            if i.issue_type != AnalysisIssueType.RELIABILITY_SESSION_LIFECYCLE:
+                continue
+            assert "'None'" not in i.message, (
+                f"R3 emitted message with 'None' literal in {fixture.name}: " f"{i.message!r}"
+            )
+
+
 # ── R4: Logging Handler Duplication ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

EPIC 4 Phase D warn soak (PRO repo, 2026-05-08) surfaced **FP-1**: R3 emitted a `RELIABILITY_SESSION_LIFECYCLE` finding at `swarm/storage/sqlite_store.py:31` (`self._conn = sqlite3.connect(...)`) despite the same class defining `close(self)` that calls `self._conn.close()`. The message also contained the literal `'None'` ("`'connect()' assigned to 'None' without ...`") — symptom of `ast.Attribute` targets falling through to `var_name=None`.

## Two bugs fixed

### 1. `ast.Attribute` target extraction
Previously: `var_name = None` if target was not `ast.Name`. Result: messages with `'None'` literal and `_has_cleanup` short-circuiting to `False`.

Now: extract **both** local-variable name (`ast.Name`) and self-attribute name (`ast.Attribute` with `value.id == "self"`). Findings whose target cannot be named are **skipped** — no more `'None'` artifacts in messages.

### 2. Cross-method cleanup recognition
Previously: cleanup detection only walked the same function. Lazy-getter cache pattern (open in `_get_conn()`, close in `close()`) was undetectable.

Now: new `_build_class_close_index(py_tree)` walks each `ClassDef` and indexes attribute names whose `close()` (or `disconnect`/`shutdown`/`dispose`) is invoked by any method. R3 suppresses findings on `self.<attr>` whose name appears in this index.

## Scope (conservative)

- ✅ Only `self.<attr>.<close-method>()` direct invocations recognized
- ✅ Local-variable detection unchanged
- ✅ `_CLOSE_METHODS` set unchanged
- ❌ No interprocedural reasoning beyond same-class close methods
- ❌ No new `_SESSION_CONSTRUCTORS`

## Tests

- `tests/fixtures/reliability_drift/r3_self_attr_managed.py` — new fixture mirroring `SwarmStore` lazy-getter pattern
- `test_r3_self_attribute_with_close_method_no_finding` — asserts R3 emits **zero** findings on the lazy-getter cache pattern
- `test_r3_message_never_contains_assigned_to_none` — regression guard scanning **every** reliability fixture for the `'None'` literal in messages
- Existing R3 positive case (`test_r3_session_lifecycle_detected`) and all other 8 reliability tests unchanged ✅

## Verification

```bash
$ python -m pytest tests/test_resource_safety_v1.py -q
10 passed in 1.03s

$ python -m black --check --line-length 100 \
    hefesto/security/packs/resource_safety_v1.py \
    tests/test_resource_safety_v1.py \
    tests/fixtures/reliability_drift/r3_self_attr_managed.py
# clean

$ python -m isort --check-only --profile black <same files>
# clean

$ python -m flake8 <same files> --max-line-length=100 --extend-ignore=E203,W503
# clean
```

## Files changed

| File | Change |
|---|---|
| `hefesto/security/packs/resource_safety_v1.py` | R3 detector: target extraction + class close index (~80 lines) |
| `tests/test_resource_safety_v1.py` | +2 tests (39 lines) |
| `tests/fixtures/reliability_drift/r3_self_attr_managed.py` | new fixture (lazy-getter pattern) |

## What did NOT change

- ❌ No PRO repo changes (separate concern)
- ❌ No policy YAML changes
- ❌ No workflow changes
- ❌ No other detectors

## Strategic impact

Unblocks **EPIC 4 Phase D promotion to `block`** scheduled for 2026-05-22 review by removing FP-1 without weakening true-positive detection. Negative-control (local variable without close) still emits R3 correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)