### PR TITLE
chore(release): bump to v4.13.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,13 +38,13 @@ hefesto/
 
 ## Key Facts
 
-- **Version:** 4.13.0
+- **Version:** 4.13.1
 - **Tests:** 531 across 38 test files
 - **Languages:** Python (native AST), TypeScript, JavaScript, Java, Go, Rust, C# (TreeSitter — requires `pip install "hefesto-ai[multilang]"`)
 - **DevOps:** YAML, Terraform, Shell, Dockerfile, SQL, PowerShell, JSON, TOML, Makefile, Groovy
 - **Cloud:** CloudFormation, ARM Templates, Helm Charts, Serverless Framework
 - **PyPI:** `pip install hefesto-ai`
-- **GitHub Action:** `artvepa80/Agents-Hefesto@v4.13.0`
+- **GitHub Action:** `artvepa80/Agents-Hefesto@v4.13.1`
 - **MCP Server:** Registered in Smithery (AI agent ecosystem)
 - **License:** MIT (core), proprietary (PRO/OMEGA features)
 
@@ -67,7 +67,7 @@ hefesto analyze .
 hefesto analyze . --fail-on HIGH --output json
 
 # GitHub Action
-- uses: artvepa80/Agents-Hefesto@v4.13.0
+- uses: artvepa80/Agents-Hefesto@v4.13.1
   with:
     target: '.'
     fail_on: 'CRITICAL'

--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -2,7 +2,7 @@
   "name": "HefestoAI",
   "description": "AI-powered code quality guardian. Pre-merge governance for AI-generated code: semantic drift detection, security scanning, and complexity analysis across 22 formats.",
   "url": "https://hefestoai.narapallc.com",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "provider": {
     "organization": "Narapa LLC",
     "url": "https://narapallc.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.13.1] - 2026-05-08
+
+### Fixed
+- **R3 detector false positive on self-managed connections** (PR #35).
+  R3 (`RELIABILITY_SESSION_LIFECYCLE`) now correctly handles `ast.Attribute`
+  assign targets such as `self._conn = sqlite3.connect(...)` and recognizes
+  the lazy-getter cache pattern: when a class assigns a connection to
+  `self.<attr>` and a sibling method invokes `self.<attr>.close()` (or
+  `disconnect`/`shutdown`/`dispose`), R3 no longer emits a finding.
+  - Eliminates messages containing the literal `'None'` literal that
+    previously surfaced when targets were not `ast.Name`.
+  - Negative-control unchanged: local-variable connections without cleanup
+    still emit R3 correctly.
+  - Added `tests/fixtures/reliability_drift/r3_self_attr_managed.py` mirroring
+    the SwarmStore lazy-getter pattern that surfaced FP-1 during EPIC 4
+    Phase D warn soak (2026-05-08).
+  - Added `test_r3_self_attribute_with_close_method_no_finding` and
+    `test_r3_message_never_contains_assigned_to_none` (regression guard).
+
 ## [4.13.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ After your AI wrote the code, but before it ships. HefestoAI verifies that what 
 
 ---
 
-## Operational Truth Analyzers (v4.13.0)
+## Operational Truth Analyzers (v4.13.1)
 
 HefestoAI's core contribution: detecting drift between what your project **declares** and what it **does**. These analyzers run automatically on every `hefesto analyze` and catch issues that linters and security scanners miss because they're not in any single file — they're in the inconsistency between files.
 
@@ -98,7 +98,7 @@ subprocess.run(["rm", user_input], check=True)
 steps:
   - uses: actions/checkout@v4
   - name: Run Hefesto Guardian
-    uses: artvepa80/Agents-Hefesto@v4.13.0
+    uses: artvepa80/Agents-Hefesto@v4.13.1
     with:
       target: '.'
       fail_on: 'CRITICAL'
@@ -144,7 +144,7 @@ npx @smithery/cli@latest mcp add artvepa80/hefestoai
 
 ---
 
-## PR Review (v4.13.0)
+## PR Review (v4.13.1)
 
 Analyze only the code changed in a pull request. Post inline comments on changed lines with deterministic dedup keys so reruns never create duplicate comments.
 
@@ -246,7 +246,7 @@ export HEFESTO_LICENSE_KEY="your-key"
 
 ---
 
-## CLI Reference (v4.13.0)
+## CLI Reference (v4.13.1)
 
 ```bash
 # Analyze code
@@ -418,7 +418,7 @@ jobs:
         run: hefesto analyze . --severity HIGH
 ```
 
-### GitHub Actions — PR Review with Inline Comments (v4.13.0)
+### GitHub Actions — PR Review with Inline Comments (v4.13.1)
 
 ```yaml
 name: Hefesto PR Review
@@ -455,7 +455,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/artvepa80/Agents-Hefesto
-    rev: v4.13.0
+    rev: v4.13.1
     hooks:
       - id: hefesto-analyze
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ hefesto analyze . --fail-on CRITICAL
 ## GitHub Action
 
 ```yaml
-- uses: artvepa80/Agents-Hefesto@v4.13.0
+- uses: artvepa80/Agents-Hefesto@v4.13.1
   with:
     target: '.'
     fail_on: 'CRITICAL'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hefesto-ai"
-version = "4.13.0"
+version = "4.13.1"
 description = "AI-Powered Code Quality Guardian — Pre-commit security & complexity analysis in 0.01s"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.artvepa80/hefestoai",
   "title": "HefestoAI",
   "description": "Pre-commit code quality guardian. Detects semantic drift in AI-generated code.",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "repository": {
     "url": "https://github.com/artvepa80/Agents-Hefesto",
     "source": "github"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@
 HefestoAI is a pre-commit code quality guardian that detects semantic drift,
 security vulnerabilities, and reliability anti-patterns in AI-generated code.
 
-Package: `hefesto-ai` (PyPI) | Version: 4.13.0 | License: MIT
+Package: `hefesto-ai` (PyPI) | Version: 4.13.1 | License: MIT
 Requires: Python >= 3.10
 
 ## When to Load These Docs


### PR DESCRIPTION
## Summary

Patch release **v4.13.1** publishing the R3 detector false-positive fix from PR #35 (commit `1b5a973`) to PyPI.

EPIC 4 Phase D warn soak surfaced FP-1 on `swarm/storage/sqlite_store.py:31` (PRO repo, 2026-05-08): R3 did not recognize `ast.Attribute` targets (`self._conn`) nor cross-method cleanup (lazy-getter cache + class-level `close()`). PR #35 fixed both issues without weakening true-positive detection. This PR publishes that fix to PyPI so PRO workflows that pull `hefesto-ai>=4.5.0,<5` begin consuming the corrected detector on their next CI run.

## Files updated

| File | Change |
|---|---|
| `pyproject.toml` | `version = "4.13.0"` → `"4.13.1"` |
| `CHANGELOG.md` | new `[4.13.1] - 2026-05-08` section under Fixed |
| `README.md` | 6 version refs |
| `llms.txt`, `server.json`, `.well-known/agent-card.json`, `skill/SKILL.md`, `.github/copilot-instructions.md` | 7 version refs |

**No code changes** — the actual fix is already on main from PR #35.

## Pre-tag verification

```bash
$ python scripts/verify_readme.py
✅ All checks passed!
   - Version: 4.13.1
   - Total: 22 formats

$ python scripts/verify_release_tag.py --tag v4.13.1 --project-root .
SUCCESS: Tag 'v4.13.1' matches pyproject version '4.13.1'

$ python -m pytest tests/test_resource_safety_v1.py tests/test_pro_wiring.py tests/test_memory_budget_gate.py -q
36 passed, 1 skipped in 4.82s
```

## Release sequence

1. Merge this PR.
2. Tag `v4.13.1` on main and push tag → triggers `.github/workflows/release.yml`.
3. release.yml runs `verify_release_tag.py`, builds wheel + sdist, runs `twine check`, uploads to PyPI, and creates GitHub Release with artifacts.
4. If PyPI upload fails (token/email issues), GitHub Release is still created (CLAUDE.md PyPI Publishing Rule).
5. Verify: `python -m pip index versions hefesto-ai` shows `4.13.1`.
6. Next PRO Swarm Gate run will install v4.13.1 and FP-1 should disappear from `RELIABILITY.json`.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: tag `v4.13.1` pushed
- [ ] `release.yml` workflow completes
- [ ] PyPI lists `4.13.1`
- [ ] PRO Swarm Gate run on main shows `RELIABILITY.json` no longer flags `swarm/storage/sqlite_store.py:31`

## Strategic context

Closes the operational gap from EPIC 4 Phase D Day 1: PR #35 fixed the detector but PRO consumes OSS via PyPI, so until v4.13.1 ships, PRO continues to see FP-1. Releasing this enables clean soak telemetry for the 2026-05-22 promotion-to-block review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)